### PR TITLE
cmake: fix distro detection to work with SUSE Build Service

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   EXECUTE_PROCESS(
       COMMAND awk -F=  "/^NAME=/ { print $2 }" /etc/os-release
       OUTPUT_VARIABLE SYS_RELEASE
-      ERROR_QUIET
+   )
+  EXECUTE_PROCESS(
+      COMMAND awk -F=  "/^ID_LIKE=/ { print $2 }" /etc/os-release
+      OUTPUT_VARIABLE ID_LIKE
    )
 # Red Hat Enterprise Linux versions before 7.0 will be detected as UNKNOWN
 
@@ -95,9 +98,15 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
      message( STATUS "Detected a Linux Debian base machine" )
      set(DISTRO "DEBIAN")
      set(LIBEXECDIR "/usr/lib")
-  else( ${SYS_RELEASE} MATCHES "Red Hat" )
-     message( STATUS "Detected an UNKNOWN Linux machine" )
-     set(DISTRO "UNKNOWN")
+  else()
+     if( ${ID_LIKE} MATCHES "suse" )
+         message( STATUS "Detected a SUSE machine" )
+         set(DISTRO "SLES")
+         set(LIBEXECDIR "/usr/lib")
+     else()
+         set(LIBEXECDIR "/usr/lib")
+         message( STATUS "Detected an UNKNOWN Linux machine" )
+     endif( ${ID_LIKE} MATCHES "suse" )
   endif( ${SYS_RELEASE} MATCHES "Red Hat" )
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 


### PR DESCRIPTION
SUSE RPM builds get /etc/os-release from an RPM called `dummy-release`
(via the line `BuildRequires: distribution-release` in `nfs-ganesha.spec`).

This RPM provides a "dummy" `/etc/os-release` file which consists of just
two lines:

```
NAME="Dummy"
ID_LIKE="suse"
```

This commit fixes `src/CMakeLists.txt` to properly set `DISTRO` to `"SLES"`
when `/etc/os-release` looks like this.

Signed-off-by: Nathan Cutler <ncutler@suse.com>